### PR TITLE
Localhost only

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ You can use this template for development both with a direct installation or wit
 * Ensure you have a running Docker daemon
 * Start the project with `docker-compose up`
 
+Note: by default the MsgFlo coordinator and MQTT ports are only available on `localhost`. Edit the ports declarations in `docker-compose.yml` if you want to open them to the outside.
+
 ## Editing in Flowhub
 
 Everything is set up so that you can edit the project in [Flowhub](https://flowhub.io)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     image: ansi/mosquitto
     container_name: mosquitto
     ports:
-      - 1883:1883
+      - '127.0.0.1:1883:1883'
     entrypoint: /usr/local/sbin/mosquitto
   msgflo:
     build: .
@@ -12,6 +12,6 @@ services:
     environment:
       MSGFLO_BROKER: 'mqtt://mqtt:1883'
     ports:
-      - 3569:3569
+      - '127.0.0.1:3569:3569'
     links:
       - mqtt


### PR DESCRIPTION
This changes the default configuration to only expose the MsgFlo coordinator and MQTT broker to localhost.